### PR TITLE
Swap Red and Blue Channels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4.0.18", features = ["derive"], optional = true }
 image = { version = "0.24.3", features = ["rgb"] }
 imageproc = "0.23.0"
 indicatif = { version = "0.17.0", optional = true }
-opencv = { version = "0.81.1", default-features = false, features = ["dnn", "imgcodecs"] }
+opencv = { version = "0.74.0", default-features = false, features = ["dnn", "imgcodecs"] }
 shellexpand = {version = "3.0.0", optional = true}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/model.rs
+++ b/src/model.rs
@@ -160,7 +160,7 @@ impl YoloModel {
                     height: self.input_size.height,
                 },
                 Scalar::new(0f64, 0f64, 0f64, 0f64),
-                false,
+                true,
                 false,
                 CV_32F,
             )?,


### PR DESCRIPTION
OpenCV by default loads images in BGR, model expects RGB